### PR TITLE
[FIX] Move Search redirect into the search namespaces

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parliament-routes (0.4.0)
+    parliament-routes (0.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -148,4 +148,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.15.4
+   1.16.0.pre.1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
   # /search
   get '/search',            to: 'search#index',      as: :search
   get '/search/opensearch', to: 'search#opensearch', as: :opensearch_description
-  get '/redirect',          to: 'search#redirect',   as: :redirect
+  get '/search/redirect',   to: 'search#redirect',   as: :redirect
 
   ### People ###
   # /people (multiple 'people' scope)

--- a/lib/parliament/engine/version.rb
+++ b/lib/parliament/engine/version.rb
@@ -1,5 +1,5 @@
 module Parliament
   module Engine
-    VERSION = '0.4.0'.freeze
+    VERSION = '0.4.1'.freeze
   end
 end


### PR DESCRIPTION
Previously, the redirect URL was /redirect. The issue with this
is that, /redirect is not represented inside our ALB routes.

Moving it into /search/redirect will allow out ALB routes to pick
it up as expected.